### PR TITLE
Feat/timeline posts

### DIFF
--- a/src/controllers/timelineController.js
+++ b/src/controllers/timelineController.js
@@ -1,4 +1,5 @@
 import { postsRepository } from '../repositories/posts.js';
+
 export async function getTimelinePosts(req, res) {
   const { userId } = res.locals;
   try {
@@ -23,4 +24,126 @@ export async function getTimelinePosts(req, res) {
   } catch (e) {
     res.status(500).send({ error: e });
   }
+}
+
+
+export async function getTimelinePosts2(req, res) {
+  const { userId, beforeDate, afterDate } = res.locals;
+  try {
+    const shares = await postsRepository.getTimelineShares(userId, beforeDate, afterDate);
+
+    // get unique posts from postId in shares
+    const uniquePostIds = shares.map((share) => share.postId);
+    const postsArray = await getPostArrayFromPostIds(uniquePostIds);
+
+    // get unique users mixing: posts userId + post comments userId + shares userId
+
+    const repeatedUserIdsArray = [];
+
+    postsArray.forEach((post) => {
+      repeatedUserIdsArray.push(post.userId);
+      post.comments.forEach((comment) => {
+        repeatedUserIdsArray.push(comment.userId);
+      });
+    });
+    shares.forEach((share) => {
+      repeatedUserIdsArray.push(share.userId);
+    })
+
+    const uniqueUserIdsArray = repeatedUserIdsArray.reduce((acc, curr) => {
+      if (!acc.some((user) => user.id === curr.id)) {
+        acc.push(curr);
+      }
+      return acc;
+    }, []);
+
+    // get usersArray with id, username, imageUrl, isFollowing
+    const usersArray = await getUserArrayFromUserIds(uniqueUserIdsArray);
+
+    // transform postsArray in posts (object based on postId)
+    const posts = {};
+    postsArray.forEach((post) => {
+      posts[post.id] = post;
+    });
+
+    // transform usersArray in users (object based on userId)
+    const users = {};
+    usersArray.forEach((user) => {
+      users[user.id] = user;
+    });
+
+    // conforming data
+    const data = {
+      shares,
+      posts,
+      users
+    }
+
+    res.send(data);
+
+  } catch (e) {
+    res.status(500).send({ error: e });
+  }
+}
+
+
+
+// ============================================================
+
+
+
+async function getPost(postId, userId) {
+  const post = await postsRepository.getPostById(postId);
+  const likes = await getLikesDataForPost(postId, userId);
+  const comments = await postsRepository.getPostComments(postId);
+  const shares = await postsRepository.getSharesInfo(postId, userId);
+  const newPost = {
+    id: post.id,
+    createdAt: post.createdAt,
+    userId: post.userId,
+    text: post.text,
+    url: { url: post.url, title: post.title, description: post.description, imageUrl: post.image },
+    likes,
+    comments,
+    shares
+  }
+  return newPost;
+}
+
+async function getPostArrayFromPostIds(postIds, userId) {
+  const postsArray = await Promise.all(
+    postIds.map(async (postId) => {
+      const post = await getPost(postId, userId);
+      return post;
+    }
+    )
+  );
+  return postsArray;
+}
+
+async function getUserArrayFromUserIds(userIds, userId) {
+  const usersArray = await Promise.all(
+    userIds.map(async (user) => {
+      const userData = await postsRepository.getOtherUserDataById(user.id, userId);
+      return userData;
+    })
+  );
+  return usersArray;
+}
+
+async function getLikesDataForPost(postId, userId) {
+  const likes = await postsRepository.getPostLikes(postId);
+  const totalLikes = likes.length;
+  const likesFiltered = likes.filter((like) => like.userId !== userId);
+  const usersWhoLiked =
+    likesFiltered.length > 0
+      ? likesFiltered.slice(0, likesFiltered.length > 2 ? 2 : likesFiltered.length)
+      : [];
+  let userHasLiked = false;
+  for (const like of likes) {
+    if (like.userId === res.locals.userId) {
+      userHasLiked = true;
+    }
+  }
+  return { userHasLiked, totalLikes, usersWhoLiked };
 }

--- a/src/middlewares/postMiddleware.js
+++ b/src/middlewares/postMiddleware.js
@@ -106,3 +106,18 @@ export async function checkIfUserHasLikedPost(req, res, next) {
     next(e);
   }
 }
+
+
+export async function checkGetPostsQuery(req, res, next) {
+  // beforeDate, afterDate, limit
+  // validate FORMAT of beforeDate and afterDate. if invalid, save null to beforeDate and afterDate.
+
+  const { beforeDate, afterDate, limit } = req.query;
+
+  res.locals.beforeDate = beforeDate && beforeDate.match(/^\d{4}-\d{2}-\d{2}$/) ? beforeDate : null;
+  res.locals.afterDate = afterDate && afterDate.match(/^\d{4}-\d{2}-\d{2}$/) ? afterDate : null;
+  res.locals.limit = limit && limit.match(/^\d+$/) ? limit : 10;
+
+  console.log(chalk.magenta(`${MIDDLEWARE} query validated`));
+  next();
+}

--- a/src/repositories/posts.js
+++ b/src/repositories/posts.js
@@ -150,6 +150,23 @@ async function deleteLikesByPostId(postId) {
   return response.rows[0];
 }
 
+/*
+
+  add those functions to the module:
+
+  [ ] getTimelineShares(userId, beforeDate, afterDate)
+  [ ] getPostById(postId)
+  [ ] getPostComments(postId)
+  [ ] getSharesInfo(postId, userId)
+  [ ] getOtherUserDataById(user.id, userId);
+  [ ] getPostLikes(postId);
+
+*/
+
+
+
+
+
 export const postsRepository = {
   getPostsByHashtagId,
   getPostsByUserId,

--- a/src/routes/timelineRouter.js
+++ b/src/routes/timelineRouter.js
@@ -1,11 +1,14 @@
 import { Router } from 'express';
 import logThis from '../blueprints/logThis.js';
-import { getTimelinePosts } from '../controllers/timelineController.js';
+import { getTimelinePosts, getTimelinePosts2 } from '../controllers/timelineController.js';
+import { validateUserId } from '../middlewares/authMiddleware.js';
+import { checkGetPostsQuery } from '../middlewares/postMiddleware.js';
 import requireToken from '../middlewares/requireToken.js';
 
 
 const timelineRouter = Router();
 
-timelineRouter.get('/posts', logThis('Get user timeline'), requireToken, getTimelinePosts);
+// timelineRouter.get('/posts', logThis('Get user timeline'), requireToken, getTimelinePosts);
+timelineRouter.get('/posts', logThis('Get user timeline'), requireToken, validateUserId, checkGetPostsQuery, getTimelinePosts2);
 
 export default timelineRouter;


### PR DESCRIPTION
![Captura de Tela 2022-06-22 às 02 05 51](https://user-images.githubusercontent.com/15219345/174947834-6b037773-c6cd-4545-8c7d-dcc0280958cf.png)

Consegui implementar a rota de timeline/posts retornando aquele formato.

Aceita 3 parâmetros (opcionais) de query string:
- beforeDate (YYY-MM-DD) [n tá 100% testado, mas em teoria vai] 
- afterDate (YYY-MM-DD) [n tá 100% testado, mas em teoria vai]
- limit [funciona]

Btw, precisamos fazer 2 ajustes no banco de dados
- Tabela posts não deve ter coluna "url"
- Tabela followings deve renomear "following_id" para "followed_id". No limite, é mais consistente pq o usuário que está seguindo é o user_id (que possui o token) e o que está sendo seguido é o followed_id.


Nota: Como não tinha rotas essenciais na main, populei o meu banco local na mão. Precisamos finalizar logo o básico.